### PR TITLE
Update games library

### DIFF
--- a/lib/src/views/games.dart
+++ b/lib/src/views/games.dart
@@ -17,8 +17,11 @@ class GameSearchModel extends AssetSearchModel<Game> {
     final List<String> lines = data.split('\n');
     final List<Game> games = <Game>[];
     for (String line in lines) {
-      if (line.isNotEmpty)
-        games.add(Game(line));
+      if (line.isNotEmpty) {
+        final List<String> cells = line.split('\t');
+        assert(cells.length == 2);
+        games.add(Game(cells.first, int.parse(cells.last)));
+      }
     }
     games.sort();
     return games;
@@ -35,9 +38,11 @@ class GameSearchModel extends AssetSearchModel<Game> {
 }
 
 class Game extends Record implements Comparable<Game> {
-  const Game(this.name);
+  const Game(this.name, this.count);
 
   final String name;
+
+  final int count;
 
   @override
   int compareTo(Game other) {
@@ -48,6 +53,10 @@ class Game extends Record implements Comparable<Game> {
   Widget buildSearchResult(BuildContext context) {
     return ListTile(
       title: Text(name),
+      trailing: Tooltip(
+        message: 'Number of copies',
+        child: Text('$count'),
+      ),
     );
   }
 }

--- a/resources/JoCoGamesCatalog.txt
+++ b/resources/JoCoGamesCatalog.txt
@@ -1,373 +1,470 @@
-13th Age
-4 the Birds
-7 Wonders
-7 Wonders Duel
-A Fake Artist Goes to New York
-AGOT Board Game
-AGOT Catan
-AGOT MoD Expansion
-Action Cats!
-Adventure Time Fluxx
-Aegis
-Age of War
-Agricola
-Agricola: Farmers of The Moor
-Alhambra
-Amberden Affair
-And then we died
-Android Mainframe
-Anomia
-Anomia Adult Version
-Anomia Kids
-Anomia Party Edition
-Apocrypha (Loneshark/Mike Selinker)
-Architects of the West Kingdom
-Arkham Horror
-Arkham Horror 3rd Edition
-Arkham Horror: The Black Goat of The Woods Expansion
-Arkham Horror: The Curse of The Dark Pharaoh Expansion
-Arkham Horror: The King in Yellow Expansion
-Arkham Horror:The Dunwich Expansion
-Ascension
-Ascension: Storm of Souls
-Attack of the Jelly Monster
-Aura
-Azul
-Back to the Future: The Card Game
-Bad Detectives
-Bananagrams
-Barkers Row
-Batman Almost Got 'Em
-Batman Fluxx
-Battle for Rokugan
-Before We Were Stars
-Betrayal At House On The Hill
-Betrayal Widows Walk Expansion
-Bill of Rights
-Blood Bowl Team Manager
-Boomtown Bandit Game
-Boss Monster 2: The Next Level
-Bottom of the 9th Game
-Braintopia 2
-Breaking Bad
-Call of Cathulu The Card Game
-Camel Up Supercup
-Captain Treasure Boots
-Car Wars Arenas
-Car Wars Classic
-Carcassonne
-Carcassonne: Hunters and Gatherers
-Cards Against Humanity
-Carrie Fisher Puzzle
-Cash and Guns
-Castellan
-Castle Ravenloft
-Catan 5-6 Player Expansion
-Catan Base Game
-Catan: Rise of the Inkas
-Chez Geek
-Choose One
-Choose Your Own Adventure
-Chromino
-Chrononauts
-Chupacabra
-Circular Reasoning
-Citadels
-Civilization
-Clank
-Clank In Space
-Coaster Park
-Codenames (Original)
-Colt Express
-Come Together
-Compound it All
-Compounded
-Concept
-Condottiere
-Council of Verona
-Coup
-Cranium
-Cribbage
-Cryptazoic Party Game Wallet
-Cthulhu's Vault
-Cthulu Fluxx
-Cutthroat Caverns
-Dead of Winter
-Deadwood Studios, USA
-Deck Building: The Deck Building Game
-Decks of cards
-Decrypto
-Defenders of Sound
-Dice Bazaar
-Dice Forge
-Discover: Lands Unknown
-Discworld: Ankh-Morpork
-Domaine
-Dragons Hoard
-Dragoon
-Dresden Files
-Druple
-Elder Sign
-Eldritch Horror
-Epic Spell Wars
-Evolution
-Evolution Climate
-Exoplanets
-Exploding Kittens
-FALLING (2014 Edition)
-FLUXX the Card Game - Basic Game
-Fake News
-Fallout
-Fate of Fantos
-Fate of the Elder Gods
-Favor of The Pharoh
-Fiasco
-Firefly Fluxx (pre-production prototype)
-Fish Cook
-Flip N' Finds Diner
-Flowerfall
-Forbidden Sky
-Fox in the Forest
-Fuse
-Galactic Strike Force
-Galactic Strike Force: Guardians of Volnoth
-Galatone
-Game of 49
-Game of Phones
-Geek Out!
-Gen7
-Get Lucky
-Get Packing
-Ghost Court
-Ghosts Love Candy
-Gingerbread House
-Give Me The Brain 4th Ed.
-Gloom
-Gloom Cthulu
-Gloom Fairy Tale
-Gloom in Space
-Gonuts for Donuts
-Ground Floor
-Guardians
-Guards! Guards! A Disc World Board Game
-Gunkimono
-Ha Ha Moustache
-Hand of the King
-Haven
-Heroes of Terrinoth
-Hey! That's My Fish
-Holding On
-Holiday Fluxx
-Honshu
-Hounded
-Human Era
-Illimat
-Illuminati
-Isle of Trains
-Jack Attack
-Jaipur
-Jenga
-Joking Hazard
-Journey to Mordor
-Junk orbit
-Just Desserts
-Just One
-Karuba Junior
-Keep Calm
-Kill Doctor Lucky
-Kill Doctor Lucky 'Mansion that is Haunted' expansion
-Kill Doctor Lucky 'Secret Lair' expansion
-Killer Bunnies
-King of Tokyo (with Power Up expansion)
-Kings Abbey
-Kittens in a Blender
-Knightmare Chess
-Koi
-Kremlin
-Kreskin's ESP
-Ladies and Gentleman
-Lanterns
-Lazer Ryderz
-Le Havre
-Letter Tycoon
-Letters from Whitechapel
-Lord of the Fries Super Deluxe
-Lord of the Fries: Chinese
-Lord of the Fries: Irish
-Lord of the Fries: Irish
-Lord of the Fries: Italian
-Lord of the Fries: Mexican
-Lords of Vegas
-Lords of Vegas UP! Expansion
-Lords of Waterdeep
-Lost In Rlyeh
-Lotus
-Love 2 Hate Politics
-Mad Love
-Madlibs
-Mansions of Madness
-Mars Attacks 10 Minute
-Mars Attacks Dice
-Mascarade
-Match Plus
-Mesozooic
-Michelangelo
-Mille Bournes
-Monikers
-Moonquake Escape
-Most Wanted
-Moustache Smash
-Munchkin Apocalypse
-Munchkin Bites
-Munchkin Booty
-Munchkin Cthulhu
-Munchkin Deluxe
-Munchkin Gloom
-Munchkin Legends Deluxe
-Munchkin Loot Letter
-Munchkin Oz
-Munchkin Pathfinder Deluxe
-Munchkin Shakespeare
-Munchkin Sketch Edition, autographed by Steve Jackson
-Munchkin Treasure Hunt
-Munchkin Zombies Deluxe
-Mysterium
-NMBR 9
-Nanuk
-Neon Gods
-New Bedford
-New California
-No Regerts
-Noisy Person Cards
-Notre Dame
-Nut So Fast
-Nutty Poses
-Once Upon A Time
-Orbis
-Pairs (Fruit Deck) with booklet
-Pairs (Troll Deck) with booklet
-Pairs Deluxe Edition
-Pairs: Goddesses of Cuisine with booklet
-Pandemic
-Pandemic: Cthulhu
-Pandemic: Fall of Rome
-Pandemic: On The Brink
-Parade
-Patchwork
-Patchwork Express
-Pathfinder Adventure Card Game: Rise of the Runelords
-Pathfinder Adventure Card Game: Skulls & Shackles
-Pathfinder Adventure Card Game: Wrath of the Righteous
-Perudo
-Pests!
-Phoenix Dawn Command
-Photosythesis
-Pickle Rick Game
-Pictomania
-Pie Town
-Pirate Dice
-Pirate Fluxx
-Pixel Lincoln
-Pocket Dungeon Quest
-Pocket Ogre
-Poop Game
-Poop Game + expansion pack
-Poop Game: Kawaii Edition
-Power Grid
-Power Grid: The First Sparks
-Pyramid Arcade
-Raiders of the North Sea
-Red Tide
-Resistor
-Retro Loonacy
-Revolution (including Palace, Anarchy)
-Rivals for Catan
-Scott Pilgrim's Little Board Game
-Secret Hitler
-Sentinel Tactics: Flame of Freedom
-Sentinels of the Multiverse
-Set Cubed
-Settlers of Catan ( very old edition)
-Shadow over Westminster
-Shadowrun Crossfire
-Shadowrun: Crossfire
-Shadows Amsterdam
-Sherlock Homes: Consulting Detective
-Skulls
-Skyline
-Smacktalk Showdown
-Smaug Puzzle
-Smile
-Space Cadets Dice Duel
-Sparkle Kitty
-Spell Smashers
-Spirit Island
-Splendor
-Spot-It
-Star Fluxx
-Star Munchkin
-Star Trek: Catan
-Starship Samurai
-Steam Park
-Steampunk Munchkin Deluxe
-Stone Age
-Stoner Fluxx
-Struggle for Catan
-Stuff and Nonsense
-Stuffed Fables
-Suddenly Drunk
-Suddenly Drunk: Gross Expansion
-Sundae Split
-Super Munchkin
-Superfight!
-Symetria
-Tags
-Tak
-Tak Pocket
-Takenoko
-Talisman
-Telestrations After Dark
-Terry Pratchett: The Witches
-Tesla vs Edison
-The Doom that Came to Atlantic City
-The Legend of Drizzt
-The Oracle of Delphi
-The River
-The Worst Case Scenario Survival Game
-Three Cheers For Master
-Thunderstone
-Ticket to Ride
-Ticket to Ride: Europe
-Ticket to Ride: NYC
-Ticket to Ride: Rails & Sails
-Tiger Puzzle
-Tigris & Euphrates
-Tiki Topple
-Tile Chess
-Tokyo Jidohanbaiki
-Tokyo Jutaku
-Tokyo Metro
-Top That Toast Game
-Train of Thought
-Trash Pandas
-Trick Taking: The Ticktaking Game
-Twilight Struggle
-Ugg- Tect
-Uglydoll Loonacy
-Unearth
-Unexploded Cow
-Unfair
-Valeria Card Kingdoms
-Veggie Garden
-Venice Puzzle
-Waggle Dance
-Walk the Plank
-Warcraft The Board Game
-Warsaw City of Ruin
-Wrath of Ashardalon
-XCOM
-Yahtzee Texas Holdem
-Yukon Salon
-Zombie Cribbage
-Zombie Dice
-Zombie Shuffle
+13th Age	1
+4 the Birds	1
+7 Wonders	2
+7 Wonders Duel	2
+A Fake Artist Goes to New York	1
+A Game of Thrones: Catan	2
+A Game of Thrones: Hand of the King	4
+A Game of Thrones: Mother of Dragons Expansion	2
+A Game of Thrones: The Board Game	2
+Abomination, The Heir of Fankenstein	1
+Action Cats!	2
+Adventure Time Fluxx	1
+Aegis	1
+Agricola (Mayfair Games)	2
+Agricola Game (ZMAN)	1
+Agricola: Farmers of The Moor	1
+Agtha Christie's Death on the Cards	1
+Alhambra	1
+Amberden Affair	2
+And then we died	1
+Android Mainframe	2
+Android: New Angeles Game	2
+Animal Upon Animal	1
+Anomia Game	1
+Anomia Kids	1
+Anomia Party Edition	1
+Anomia X Game: Adult Version	1
+Apocrypha (Loneshark/Mike Selinker)	1
+Architects of the West Kingdom	2
+Arkahm Horror, Final Hour	1
+Arkham Horror	1
+Arkham Horror 3rd Edition	2
+Arkham Horror: The Black Goat of The Woods Expansion	1
+Arkham Horror: The Curse of The Dark Pharaoh Expansion	1
+Arkham Horror: The Dunwich Expansion	1
+Arkham Horror: The King in Yellow Expansion	1
+Ascension	1
+Ascension: Storm of Souls	1
+Attack of the Jelly Monster	2
+Aura	1
+Azul	2
+Azul Summer Pavilion	1
+Back to the Future: The Card Game	1
+Bad Detectives	1
+Balderdash Game	1
+Bananagrams	1
+Banned Words Game by Wonderforge	1
+Barenpark	1
+Barenpark: The Bad News Bears	1
+Barkers Row	1
+Batman Almost Got 'Em	1
+Batman Fluxx	1
+Battle for Rokugan	2
+Bears vs Babies	3
+Bears vs Babies NSFW Expansion Pack	1
+Before We Were Stars	1
+Betrayal At House On The Hill	2
+Betrayal Widows Walk Expansion	2
+Blood Bowl Team Manager	1
+Bob Ross Art of Chill	1
+Boomtown Bandit Game	2
+Boss Monster 2: The Next Level	3
+Bottom of the 9th Game	2
+Braintopia	1
+Braintopia Beyond	2
+Brawl	1
+Breaking Bad	2
+Burger Battle Game	1
+Button Men	1
+Call of Cathulu The Card Game	1
+Camel Cup	1
+Camel Up Supercup	2
+Captain Treasure Boots	1
+Car Wars Arenas	1
+Car Wars Classic	1
+Carcassonne	4
+Carcassonne: Hunters and Gatherers	1
+Cards Against Humanity	3
+Carrie Fisher Puzzle	1
+Cash 'n Guns: Second Edition	1
+Castellan	2
+Castle Ravenloft	1
+Catan 5-6 Player Expansion	2
+Catan Base Game 5th Edition	4
+Catan: Rise of the Inkas	2
+Catan: Starfarers	1
+Catlantis game	1
+Chez Geek	1
+Choose One	1
+Choose Your Own Adventure: House of Danger	4
+Choose Your Own Adventure: War With the Evil Power Master	1
+Chromino	2
+Chronicles of Crime	1
+Chrononauts	1
+Chupacabra	1
+Circular Reasoning	1
+Citadels	1
+Cities of Splendor Expansions	2
+Civilization: A New Dawn Game	2
+Clank	2
+Clank In Space	2
+Coaster Park	1
+Codenames (Original)	1
+Colt Express	1
+Come Together	1
+Compounded	1
+Concept	2
+Condottiere	2
+Corinth	1
+Council of Verona	1
+Coup	1
+Cranium Dark	1
+Cribbage	1
+Cryptazoic Party Game Wallet	1
+Cthulhu's Vault	4
+Cthulu Fluxx	1
+Cutthroat Caverns	1
+D&D Dungeon Master Screen	5
+D&D Player's Handbook	3
+Dead of Winter	3
+Deadwood Studios, USA	1
+Deck Building: The Deck Building Game	1
+Decks of cards	11
+Decrypto	1
+Defenders of Soma	1
+Dice Bazaar	1
+Dice Forge	1
+Diceborn Heroes	1
+Dinosaur Tea Party	1
+Dirty Words	1
+Discover: Lands Unknown	2
+Discworld: Ankh-Morpork	1
+Disney Villainous: The Worst Takes It All	1
+Domaine	1
+Dragons Hoard	1
+Dragoon	3
+Dude	1
+Duple	1
+Elder Sign	2
+Eldritch Horror	2
+Epic Spell Wars	1
+Evolution	1
+Evolution Climate	1
+Exoplanets	2
+Exploding Kittens	3
+Exploding Kittens NSFW	3
+FALLING (2014 Edition)	1
+FLUXX the Card Game - Basic Game	2
+Fake News	1
+Fallout	2
+Fate of Fantos	1
+Fate of the Elder Gods	2
+Favor of the Pharaoh game	1
+Fiasco	1
+Final Boss: the Card Game	1
+Firefly Fluxx (pre-production prototype)	2
+Fish Cook	1
+Flip N' Finds Diner	1
+Flowerfall	1
+Fog of Love	1
+Forbidden Sky	1
+Fox in the Forest	1
+Funemployed	1
+Funkoverse DC	1
+Funkoverse Harry Potter	1
+Fuse	4
+Galactic Strike Force (with Guardians of Volnoth expansion)	1
+Galatune	1
+Game of 49	1
+Ganymede	1
+Geek Out!	1
+Gen7	2
+Get Lucky	1
+Get Packing	2
+Ghost Court	1
+Ghostel	1
+Ghosts Love Candy	1
+Gingerbread House	2
+Give Me the Brain	1
+Gloom	1
+Gloom Cthulu	1
+Gloom Fairy Tale	1
+Gloom in Space	1
+Godsforge	1
+Gonuts for Donuts	1
+Ground Floor	1
+Guardians	2
+Guards! Guards! A Disc World Board Game	1
+Gunkimono	2
+Ha Ha Moustache	1
+Hanabi	2
+Happy Salmon	1
+Haven	1
+Heads Talk Tails Walk	1
+Here, Fishy, Fishy!	1
+Hero Realms	1
+Hero Realms: The  Ruin of Thandar Campaign Deck	1
+Heroes of Terrinoth	2
+Hey! That's My Fish	2
+Holding On	2
+Holiday Fluxx	1
+Honshu	2
+Hop! Hop! Hop!	1
+Horrified: Universal Monsters Game	6
+Hounded	2
+Human Era	6
+Illimat	2
+Illuminati	1
+Imploding Kittens	2
+Incubation	6
+Isle of Trains	1
+Its a Wonderful World	1
+Jack Attack	1
+Jaipur	4
+Jaws Game	6
+Jenga	1
+Jetpack Joyride	1
+Joking Hazard	4
+Jungle Speed	1
+Junk orbit	2
+Just Desserts	1
+Just One	4
+KDL Mansion that is Haunted expansion board with loose rules, pawns, and deck	1
+Karuba Junior	1
+Keep Calm	1
+Killer Bunnies	1
+King of Tokyo (with Power Up Expansion)	1
+Kings Abbey	1
+Kittens in a Blender	1
+Koi	1
+Kremlin	2
+Kreskin's ESP	1
+Lanterns	1
+Last Bastion	1
+Lazer Ryderz	2
+Le Havre	1
+Letter Tycoon	1
+Letters from Whitechapel	2
+Lions and Tigers and Bears, Oh My!	1
+Living Labyrinth Game	1
+Lord of the Fries Super Deluxe	1
+Lord of the Fries: Chinese	1
+Lord of the Fries: Irish	1
+Lord of the Fries: Italian	1
+Lords of Vegas	2
+Lords of Vegas UP! Expansion	1
+Lords of Waterdeep	1
+Lost In Rlyeh	2
+Lotus	4
+Love Letter	2
+Mad Love	1
+Madlibs	1
+Mansions of Madness	1
+Mars Attacks: the Dice Game	1
+Marvel Champions the Card Game	1
+Match Plus	1
+Meeple Party	6
+MegaCity Oceania	1
+Mesozooic	4
+Mice and Mystics	1
+Mille Bornes	4
+Monikers	2
+Moonquake Escape	1
+More Dude	1
+Most Wanted	1
+Moustache Smash	1
+Mr. Jack	1
+Munchkin Apocalypse	1
+Munchkin Bites	1
+Munchkin Booty	1
+Munchkin Cthulhu	1
+Munchkin Deluxe	1
+Munchkin Gloom	1
+Munchkin Legends Deluxe	1
+Munchkin Loot Letter	1
+Munchkin Oz	1
+Munchkin Pathfinder Deluxe	1
+Munchkin Shakespeare	1
+Munchkin Sketch Edition, autographed by Steve Jackson	1
+Munchkin Treasure Hunt	1
+Munchkin Zombies Deluxe	1
+Mysterium	2
+Mystery House, Adventures in a Box	1
+NMBR 9	4
+Naga Raja	1
+Nanuk	1
+Narabi	1
+Narwhal Free for All	1
+Neon Gods	2
+New Bedford	1
+No Regerts	1
+Noctiluca	1
+Noisy Person Cards	3
+Notre Dame	1
+Nut So Fast	1
+Obscurio	1
+On A Scale of One to T-Rex	2
+Once Upon A Time	1
+One More Dude	1
+Orbis	2
+Pairs (Fruit Deck) with booklet	1
+Pairs (Troll Deck) with booklet	1
+Pairs Deluxe Edition	1
+Pandemic	4
+Pandemic: Cthulhu	2
+Pandemic: Fall of Rome	2
+Pandemic: Iberia	1
+Pandemic: On The Brink Expansion	1
+Pandemic: Rapid Response	1
+Parade	2
+Patchwork	2
+Patchwork Express	2
+Pathfinder Adventure Card Game: Rise of the Runelords	1
+Pathfinder Adventure Card Game: Skulls & Shackles	1
+Pathfinder Adventure Card Game: Wrath of the Righteous	1
+Perudo	2
+Pests!	1
+Photosynthesis	1
+Pickle Rick Game	1
+Pictomania	1
+Pie Town	1
+Pirate Den Game	1
+Pirate Dice	1
+Pirate Fluxx	1
+Pixel Lincoln	1
+Pocket Ogre	2
+Poop Game + expansion pack	3
+Poop Game: Kawaii Edition	1
+Potato Pirates	1
+Power Grid	1
+Power Grid: The First Sparks	1
+Pretending to Grow Up	1
+Push Game	6
+Pyramid Arcade	1
+Quacks of Quedlinburg	3
+Quarriors (with Quest of Qladiator, Rise of Demons, and Quarmageddon expansions)	1
+Queen Domino	1
+Quicktionary	1
+Raiders of the North Sea	2
+Red Tide	1
+Res Arcana	1
+Resistor	4
+Retro Loonacy	1
+Revolution (with Palace and Anarchy expansions)	1
+Rhino Hero Super Battle	1
+Rivals for Catan	2
+Root	1
+Say Anything	1
+Scott Pilgrim's Little Board Game	1
+Secret Hitler	5
+Sentinel Tactics: Flame of Freedom	1
+Sentinels of the Multiverse	1
+Set Cubed	1
+Settlers of Catan (very old edition)	1
+Shadow over Westminster	1
+Shadowrun: Crossfire	2
+Shadowrun: Crossfire	2
+Shadows Amsterdam	2
+Sherlock Holmes: Consulting Detective	1
+Sherlock Holmes: Consulting Detective, Carlton House	1
+Sherlock Holmes: Consulting Detective, Jack the Ripper	1
+Sherlock Holmes: Consulting Detective, The Thames Murders	1
+Skull	4
+Skyline	1
+Smacktalk Showdown	1
+Smaug Puzzle	1
+Smile	2
+Space Cadets Dice Duel	1
+Space Gate Odyssey	1
+Sparkle Kitty	1
+Spell Smashers	2
+Spirit Island	2
+Splendor	3
+Spot It!	6
+Star Fluxx	1
+Star Munchkin	1
+Star Realms Frontiers	1
+Star Trek Catan: Federation Space, a 2 Map Expansion for Star Trek Catan	2
+Star Wars, Outer Rim	1
+Starship Samurai	2
+Steam Park	1
+Steampunk Munchkin Deluxe	1
+Stellar Leap	1
+Stone Age	2
+Stoner Fluxx	1
+Streaking Kittens, Exploding Kittens Expansion Pack	2
+Struggle for Catan	2
+Stuff and Nonsense	1
+Stuffed Fables	2
+Suddenly Drunk	1
+Suddenly Drunk + Suddenly Drunk: Gross Expansion	1
+Suddenly Drunk: Gross Expansion	1
+Suddenly Drunk: Hardcore Expansion	1
+Suddenly Drunk: Sexy Expansion	1
+Sultaniya	1
+Sundae Split	1
+Sundae Split	1
+Super Munchkin	1
+Super Punch Fighter	1
+Superfight! Card Game - Superfight! Core Game 2.0	3
+Symetra	1
+Tags	2
+Tak	2
+Tak Pocket	1
+Takenoko	2
+Talisman	1
+Telestrations After Dark	1
+Terry Pratchett: The Witches	1
+Tesla vs Edison	1
+The Cities & Knights of Catan Game	1
+The Cousin's War	1
+The Doom that Came to Atlantic City	1
+The Island of Doctor Lucky	2
+The Jane Game	1
+The Legend of Drizzt	1
+The Legend of the Cherry Tree That Blossoms Every Ten Years	1
+The Lord of The Rings: Journey to Mordor	2
+The Oracle of Delphi	1
+The River	2
+The Works	1
+The Worst Case Scenario Survival Game	1
+Three Cheers For Master	2
+Throw Throw Burrito	2
+Thunderstone	1
+Ticket to Ride	4
+Ticket to Ride: Europe	2
+Ticket to Ride: London	1
+Ticket to Ride: New York	4
+Ticket to Ride: Rails & Sails	2
+Tiger Puzzle	1
+Tigris & Euphrates	1
+Tiki Island	1
+Tiki Topple	1
+Tile Chess	1
+Tokyo Highway	1
+Tokyo Jidohanbaiki	2
+Tokyo Jutaku	2
+Tokyo Metro	3
+Topiary	1
+Train of Thought	1
+Trash Pandas	1
+Trick Taking: The Ticktaking Game	1
+Twilight Struggle	1
+Ugg-Tect	1
+Uglydoll Loonacy	1
+Unearth	2
+Unexploded Cow	1
+Unfair	1
+Unlock! Mystery Adventures, The Toni Pals Treasure	11
+Valeria Card Kingdoms	1
+Vast, the Haunted Hallways	1
+Vast, the Mysterious Mannor	1
+Veggie Garden	1
+Venice Puzzle	1
+Villainous	1
+Waggle Dance	1
+Walk the Plank	1
+Warcraft The Board Game	1
+Warsaw City of Ruins	1
+Wavelength	1
+Who Took My Eggs?	1
+Wolfy	1
+Wrath of Ashardalon	1
+XCOM	2
+Yahtzee Texas Holdem	1
+You Think You Know Me	1
+You've Got Crabs	2
+Yukon Salon	1
+Zombie Cribbage	1
+Zombie Dice	3


### PR DESCRIPTION
Here's the delta from the official games library. I corrected some
typos and made some of the titles and annotations more consistent with
each other.

```diff
--- JoCoGamesCatalog.txt.2	2020-02-03 23:18:39.158521726 -0800
+++ JoCoGamesCatalog.txt	2020-02-03 23:04:24.547067443 -0800
@@ -3,10 +3,10 @@
 7 Wonders	2
 7 Wonders Duel	2
 A Fake Artist Goes to New York	1
+A Game of Thrones: Catan	2
 A Game of Thrones: Hand of the King	4
-AGOT Board Game	2
-AGOT Catan	2
-AGOT MoD Expansion	2
+A Game of Thrones: Mother of Dragons Expansion	2
+A Game of Thrones: The Board Game	2
 Abomination, The Heir of Fankenstein	1
 Action Cats!	2
 Adventure Time Fluxx	1
@@ -24,7 +24,6 @@
 Anomia Game	1
 Anomia Kids	1
 Anomia Party Edition	1
-Anomia Party Edition	1
 Anomia X Game: Adult Version	1
 Apocrypha (Loneshark/Mike Selinker)	1
 Architects of the West Kingdom	2
@@ -33,8 +32,8 @@
 Arkham Horror 3rd Edition	2
 Arkham Horror: The Black Goat of The Woods Expansion	1
 Arkham Horror: The Curse of The Dark Pharaoh Expansion	1
+Arkham Horror: The Dunwich Expansion	1
 Arkham Horror: The King in Yellow Expansion	1
-Arkham Horror:The Dunwich Expansion	1
 Ascension	1
 Ascension: Storm of Souls	1
 Attack of the Jelly Monster	2
@@ -52,8 +51,8 @@
 Batman Almost Got 'Em	1
 Batman Fluxx	1
 Battle for Rokugan	2
+Bears vs Babies	3
 Bears vs Babies NSFW Expansion Pack	1
-Bears vs. Babies	3
 Before We Were Stars	1
 Betrayal At House On The Hill	2
 Betrayal Widows Walk Expansion	2
@@ -130,7 +129,7 @@
 Dinosaur Tea Party	1
 Dirty Words	1
 Discover: Lands Unknown	2
-Discworld ANKH- More Pork	1
+Discworld: Ankh-Morpork	1
 Disney Villainous: The Worst Takes It All	1
 Domaine	1
 Dragons Hoard	1
@@ -154,21 +153,18 @@
 Favor of the Pharaoh game	1
 Fiasco	1
 Final Boss: the Card Game	1
-Firefly Fluxx - this is a pre-production prototype of the game that will be released in March.	2
+Firefly Fluxx (pre-production prototype)	2
 Fish Cook	1
 Flip N' Finds Diner	1
 Flowerfall	1
 Fog of Love	1
-Fog of Love 	1
 Forbidden Sky	1
 Fox in the Forest	1
 Funemployed	1
 Funkoverse DC	1
-Funkoverse DC	1
-Funkoverse Harry Potter	1
 Funkoverse Harry Potter	1
 Fuse	4
-Galactic Strike Force w/ Guardians of Volnoth expansion	1
+Galactic Strike Force (with Guardians of Volnoth expansion)	1
 Galatune	1
 Game of 49	1
 Ganymede	1
@@ -228,7 +224,7 @@
 Karuba Junior	1
 Keep Calm	1
 Killer Bunnies	1
-King of Tokyo ( With Power Up Expansion)	1
+King of Tokyo (with Power Up Expansion)	1
 Kings Abbey	1
 Kittens in a Blender	1
 Koi	1
@@ -262,7 +258,7 @@
 MegaCity Oceania	1
 Mesozooic	4
 Mice and Mystics	1
-Mille Bournes	4
+Mille Bornes	4
 Monikers	2
 Moonquake Escape	1
 More Dude	1
@@ -337,7 +333,7 @@
 Push Game	6
 Pyramid Arcade	1
 Quacks of Quedlinburg	3
-Quarriors ( with Quest of Qladiator, Rise of Demons, Quarmageddon Expansions) 	1
+Quarriors (with Quest of Qladiator, Rise of Demons, and Quarmageddon expansions)	1
 Queen Domino	1
 Quicktionary	1
 Raiders of the North Sea	2
@@ -345,7 +341,7 @@
 Res Arcana	1
 Resistor	4
 Retro Loonacy	1
-Revolution (incl. Palace, Anarchy)	1
+Revolution (with Palace and Anarchy expansions)	1
 Rhino Hero Super Battle	1
 Rivals for Catan	2
 Root	1
@@ -355,15 +351,15 @@
 Sentinel Tactics: Flame of Freedom	1
 Sentinels of the Multiverse	1
 Set Cubed	1
-Settlers of Catan ( very old edition)	1
+Settlers of Catan (very old edition)	1
 Shadow over Westminster	1
 Shadowrun: Crossfire	2
 Shadowrun: Crossfire	2
 Shadows Amsterdam	2
+Sherlock Holmes: Consulting Detective	1
 Sherlock Holmes: Consulting Detective, Carlton House	1
 Sherlock Holmes: Consulting Detective, Jack the Ripper	1
 Sherlock Holmes: Consulting Detective, The Thames Murders	1
-Sherlock Homes: Consulting Detective	1
 Skull	4
 Skyline	1
 Smacktalk Showdown	1
@@ -375,7 +371,7 @@
 Spell Smashers	2
 Spirit Island	2
 Splendor	3
-Spot-It	6
+Spot It!	6
 Star Fluxx	1
 Star Munchkin	1
 Star Realms Frontiers	1
@@ -402,7 +398,7 @@
 Super Munchkin	1
 Super Punch Fighter	1
 Superfight! Card Game - Superfight! Core Game 2.0	3
-Symetria ( unknown game)	1
+Symetra	1
 Tags	2
 Tak	2
 Tak Pocket	1
@@ -411,6 +407,7 @@
 Telestrations After Dark	1
 Terry Pratchett: The Witches	1
 Tesla vs Edison	1
+The Cities & Knights of Catan Game	1
 The Cousin's War	1
 The Doom that Came to Atlantic City	1
 The Island of Doctor Lucky	2
@@ -422,14 +419,12 @@
 The River	2
 The Works	1
 The Worst Case Scenario Survival Game	1
-The cities & Knights of Catan Game	1
-Three Cheers For Master	2
 Three Cheers For Master	2
 Throw Throw Burrito	2
 Thunderstone	1
-Ticket To  Ride: London	1
 Ticket to Ride	4
 Ticket to Ride: Europe	2
+Ticket to Ride: London	1
 Ticket to Ride: New York	4
 Ticket to Ride: Rails & Sails	2
 Tiger Puzzle	1
@@ -446,7 +441,7 @@
 Trash Pandas	1
 Trick Taking: The Ticktaking Game	1
 Twilight Struggle	1
-Ugg- Tect	1
+Ugg-Tect	1
 Uglydoll Loonacy	1
 Unearth	2
 Unexploded Cow	1
@@ -468,9 +463,8 @@
 Wrath of Ashardalon	1
 XCOM	2
 Yahtzee Texas Holdem	1
+You Think You Know Me	1
 You've Got Crabs	2
 Yukon Salon	1
 Zombie Cribbage	1
 Zombie Dice	3
-you think you know me	1
-ƒ	1
```