### PR TITLE
fix prefer_const_constructors lint

### DIFF
--- a/lib/src/views/karaoke.dart
+++ b/lib/src/views/karaoke.dart
@@ -117,7 +117,7 @@ class SongSearchModel extends AssetSearchModel<Song> {
             ),
           ),
           PopupMenuButton<bool>(
-            icon: Icon(Icons.sort),
+            icon: const Icon(Icons.sort),
             onSelected: (bool result) { setState(() { _sortByTitles = result; }); },
             itemBuilder: (BuildContext context) => <PopupMenuEntry<bool>>[
               CheckedPopupMenuItem<bool>(

--- a/lib/src/views/profile_editor.dart
+++ b/lib/src/views/profile_editor.dart
@@ -208,7 +208,7 @@ class _ProfileEditorState extends State<ProfileEditor> {
                   actions: <Widget>[
                     if (_pending.isNotEmpty)
                       IconButton(
-                        icon: Icon(Icons.cancel),
+                        icon: const Icon(Icons.cancel),
                         tooltip: 'Cancel current edit',
                         onPressed: () {
                           _pending.cancelAll();

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -1737,7 +1737,7 @@ class PhotoImage extends StatelessWidget {
                                     iconTheme: const IconThemeData(color: Colors.white),
                                     actions: <Widget>[
                                       IconButton(
-                                        icon: Icon(Icons.cloud_download),
+                                        icon: const Icon(Icons.cloud_download),
                                         tooltip: 'Download image to device',
                                         onPressed: () async {
                                           final Map<PermissionGroup, PermissionStatus> permissions = await PermissionHandler()


### PR DESCRIPTION
The latest Dart SDK has bug fixes for the prefer_const_constructors lint. Updating the missing `const` now so that we can roll without errors.